### PR TITLE
updated function 'buildSamlResponse' when calling the 'computeSignatu…

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -48,7 +48,7 @@ function buildSamlResponse(options) {
       }
     };
 
-    sig.computeSignature(cannonicalized, { prefix: options.signatureNamespacePrefix });
+    sig.computeSignature(cannonicalized, { prefix: options.signatureNamespacePrefix, location: options.location });
     SAMLResponse = sig.getSignedXml();
   }
 


### PR DESCRIPTION
…re' method to pass location object containing action & reference properties to enable different Response signature locations